### PR TITLE
Fail Installation of Unsupported Versions

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -5,7 +5,15 @@ install_postgres_app() {
   local version=$2
   local install_path=$3
 
-  ln -s /Applications/Postgres.app/Contents/Versions/$version/bin $install_path
+  local version_path=/Applications/Postgres.app/Contents/Versions/$version/bin
+
+  if [ -d $version_path ]; then
+    ln -s $version_path $install_path
+    echo "Installed version $version"
+  else
+    echo -e "Version $version is not supported by your installed Postgres.app distribution.\nUse 'asdf list-all postgres-app' to see all supported versions.\nIf the desired version is missing make sure to check https://postgresapp.com/downloads.html for different distributions."
+    exit 1
+  fi
 }
 
 install_postgres_app $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH


### PR DESCRIPTION
Currently the installation scripts runs successful even for versions that don't exist.
This is problematic since ASDF will treat this version as installed (Outputting `is already installed` when trying to install it again), but fail when using a `.tools_versions` file which this version listed.

The root cause of the problem is that creating a symlink does not check the existence of the symlink destination so we need to do this ourself.
Trying to install a unsupported version will yield an error message:

```
Version 12.4 is not supported by your installed Postgres.app distribution.
Use 'asdf list-all postgres-app' to see all supported versions.
If the desired version is missing make sure to check https://postgresapp.com/downloads.html for different distributions.
```

This issue was discovered since we had a `.tools_versions` file containing `postgres-app 12.4` which is supported by the latest Postgres.app version but is internally called `12` which is the version we need to specify in the `.tools_versions` file.

```
❯ ls -all /Applications/Postgres.app/Contents/Versions
total 0
drwxr-xr-x@  9 User  admin  288 Sep 24 11:15 ./
drwxr-xr-x@ 10 User  admin  320 Sep 24 11:16 ../
drwxr-xr-x@  6 User  admin  192 Sep 24 11:12 10/
drwxr-xr-x@  6 User  admin  192 Sep 24 11:13 11/
drwxr-xr-x@  6 User  admin  192 Sep 24 11:14 12/
drwxr-xr-x@  6 User  admin  192 Sep 24 11:15 13/
drwxr-xr-x@  6 User  admin  192 Sep 24 11:11 9.5/
drwxr-xr-x@  6 User  admin  192 Sep 24 11:11 9.6/
lrwxr-xr-x   1 User  admin    2 Sep 24 11:24 latest@ -> 13
```